### PR TITLE
add attributes to fix dead_code and unused_imports

### DIFF
--- a/src/a+b.rs
+++ b/src/a+b.rs
@@ -1,14 +1,17 @@
 // Implements http://rosettacode.org/wiki/A%2BB
 
+#![allow(unused_imports)]
 use std::io::stdio::stdin;
 use std::from_str::from_str;
 use std::io::BufferedReader;
 
+#[cfg(not(test))]
 fn main() {
     let input = BufferedReader::new(stdin()).read_line().unwrap();
     let mut words = input.words();
 
-    let sum = match (words.next().and_then(from_str::<int>), words.next().and_then(from_str)) {
+    let sum = match (words.next().and_then(from_str::<int>),
+                     words.next().and_then(from_str)) {
         (Some(a), Some(b)) => a + b,
         _                  => fail!("Please enter 2 integers")
     };

--- a/src/almost_prime.rs
+++ b/src/almost_prime.rs
@@ -1,5 +1,6 @@
 // Implements http://rosettacode.org/wiki/Almost_prime
 
+#[allow(unused_imports)]
 use std::iter::{count, range_inclusive};
 
 fn is_kprime(mut n: uint, k: uint) -> bool {
@@ -17,12 +18,13 @@ fn is_kprime(mut n: uint, k: uint) -> bool {
     f + (n > 1) as uint == k
 }
 
-fn get_kprimes(k: uint, amount: uint) -> Vec<uint> {   
+fn get_kprimes(k: uint, amount: uint) -> Vec<uint> {
     count(2u, 1).filter(|&x| is_kprime(x, k))
                 .take(amount)
                 .collect()
 }
 
+#[cfg(not(test))]
 fn main() {
     for k in range_inclusive(1u, 5) {
         println!("k = {}: {}", k, get_kprimes(k, 10));
@@ -33,16 +35,16 @@ fn main() {
 fn test_almost_primes() {
     // k = 1
     assert!(get_kprimes(1, 10).as_slice() == [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]);
-    
+
     // k = 2
     assert!(get_kprimes(2, 10).as_slice() == [4, 6, 9, 10, 14, 15, 21, 22, 25, 26]);
-    
+
     // k = 3
     assert!(get_kprimes(3, 10).as_slice() == [8, 12, 18, 20, 27, 28, 30, 42, 44, 45]);
-    
+
     // k = 4
     assert!(get_kprimes(4, 10).as_slice() == [16, 24, 36, 40, 54, 56, 60, 81, 84, 88]);
-    
+
     // k = 5
     assert!(get_kprimes(5, 10).as_slice() == [32, 48, 72, 80, 108, 112, 120, 162, 168, 176]);
 }

--- a/src/anagrams.rs
+++ b/src/anagrams.rs
@@ -4,6 +4,8 @@ extern crate collections;
 
 use collections::{HashMap, HashSet};
 use std::str;
+
+#[cfg(not(test))]
 use std::io::{File, BufferedReader};
 use std::cmp::max;
 
@@ -26,13 +28,13 @@ fn get_anagrams<T: Buffer>(mut reader: T) -> HashMap<~str, HashSet<~str>> {
 			|_, group| { group.insert(s.clone()); }                       // The closure to update the value
 		);
 	}
-    
+
     groups
 }
 
 // Returns the groups of anagrams that contain the most words in them
 fn get_biggest_groups(groups: &HashMap<~str, HashSet<~str>>) -> HashMap<~str, HashSet<~str>> {
-    let max_length = groups.iter().fold(0, |current_max, (_, group)| max(current_max, group.len())); 
+    let max_length = groups.iter().fold(0, |current_max, (_, group)| max(current_max, group.len()));
     groups.iter().filter(|&(_, group)| group.len() == max_length).map(|(x, y)| (x.clone(), y.clone())).collect()
 }
 
@@ -64,22 +66,22 @@ fn basic_test() {
     // We will get a string like "lane\nneal\nlean\nangel\nangle\ngalen\nglare\nlarge"
     let mut word_iter = group1.iter().chain(group2.iter().chain(group3.iter()));
     let mut words = StrBuf::new();
-    
+
     words.push_str(word_iter.next().unwrap().as_slice());
     for word in word_iter {
         words.push_str("\n");
         words.push_str(word.as_slice());
     }
-    
+
     // Here begins the real testing
     let all_groups = get_anagrams(std::io::MemReader::new(words.to_str().bytes().collect()));
     let biggest_groups = get_biggest_groups(&all_groups);
-    
+
     // Groups 1, 2 and 3 are contained in "all_groups"
     assert!(all_groups.iter().any(|(_, group)| *group == group1));
     assert!(all_groups.iter().any(|(_, group)| *group == group2));
     assert!(all_groups.iter().any(|(_, group)| *group == group3));
-    
+
     // Groups 1 and 2 are contained in "biggest_groups". Group 3 is not.
     assert!(biggest_groups.iter().any(|(_, group)| *group == group1));
     assert!(biggest_groups.iter().any(|(_, group)| *group == group2));

--- a/src/arithmetic_integers.rs
+++ b/src/arithmetic_integers.rs
@@ -1,13 +1,15 @@
 // Implements http://rosettacode.org/wiki/Arithmetic/Integer
 
+#![allow(unused_imports)]
 use std::io::stdio::stdin;
 use std::from_str::from_str;
 use std::io::BufferedReader;
 
+#[cfg(not(test))]
 fn main() {
     let input = BufferedReader::new(stdin()).read_line().unwrap();
     let mut words = input.words();
-    
+
     let (a, b) = match (words.next().and_then(from_str::<int>), words.next().and_then(from_str::<int>)) {
             (Some(x), Some(y)) => (x, y),
             _                  => fail!("Please enter 2 integers")

--- a/src/arithmetic_mean.rs
+++ b/src/arithmetic_mean.rs
@@ -11,6 +11,7 @@ fn mean(list: &[f64]) -> Option<f64> {
     }
 }
 
+#[cfg(not(test))]
 fn main() {
     let input = vec!(3.0, 1.0, 4.0, 1.0, 5.0, 9.0);
 

--- a/src/balanced_brackets.rs
+++ b/src/balanced_brackets.rs
@@ -2,12 +2,13 @@
 
 extern crate rand;
 
+#[cfg(not(test))]
 use rand::random;
 
 // Returns true if the brackets are balanced
 fn check_balanced(bracket_str: &str) -> bool {
     let mut count = 0;
-    
+
     for bracket in bracket_str.chars() {
         match bracket {
             '[' => {
@@ -22,14 +23,15 @@ fn check_balanced(bracket_str: &str) -> bool {
             _ => { fail!("Strings containing characters other than brackets are not allowed"); }
         }
     }
-    
+
     count == 0
 }
 
 // Generates random brackets
-fn generate_brackets(mut num: uint) -> StrBuf {
+#[cfg(not(test))]
+fn generate_brackets(num: uint) -> StrBuf {
     let mut brackets = StrBuf::new();
-    
+
     for _ in range(0, num) {
         if random() {
             brackets.push_char('[')
@@ -37,7 +39,7 @@ fn generate_brackets(mut num: uint) -> StrBuf {
             brackets.push_char(']')
         }
     }
-    
+
     brackets
 }
 

--- a/src/binary_digits.rs
+++ b/src/binary_digits.rs
@@ -1,5 +1,6 @@
 // Implements http://rosettacode.org/wiki/Binary_digits
 
+#[cfg(not(test))]
 fn main() {
     for i in range(0, 16) {
         println!("{:t}", i)

--- a/src/bubble_sort.rs
+++ b/src/bubble_sort.rs
@@ -14,6 +14,7 @@ fn bubble_sort<T: Ord>(v: &mut[T]) {
     }
 }
 
+#[cfg(not(test))]
 fn main() {
     let mut numbers = [4, 65, 2, -31, 0, 99, 2, 83, 782, 1];
     bubble_sort(numbers);

--- a/src/call_foreign_function.rs
+++ b/src/call_foreign_function.rs
@@ -2,14 +2,18 @@
 
 extern crate libc;
 
+#[cfg(not(test))]
 use libc::c_char;
+#[cfg(not(test))]
 use std::c_str::CString;
 
+#[cfg(not(test))]
 extern "C" {
     // C functions are declared in an `extern "C"` block.
     fn strdup(s: *c_char) -> *c_char;
 }
 
+#[cfg(not(test))]
 fn main() {
     // Create a Rust static string. No allocations.
     let rust_str = "Hello World!";

--- a/src/callback_to_array.rs
+++ b/src/callback_to_array.rs
@@ -1,15 +1,17 @@
 // Implements http://rosettacode.org/wiki/Apply_a_callback_to_an_array
 
+#[cfg(not(test))]
 fn main () {
     let array = [1,2,3,4,5];
-    
+
     println!("{}", array.as_slice());
-    
+
     // The map does not mofify the array. It just returns an iterator.
     // We iterate through the results of map and collect them into a vector.
     println!("{}", array.iter().map(callback).collect::<Vec<int>>());
 }
 
+#[cfg(not(test))]
 fn callback(val: &int) -> int {
     val + 1
 }

--- a/src/check_file.rs
+++ b/src/check_file.rs
@@ -1,5 +1,6 @@
 // Implements http://rosettacode.org/wiki/Check_that_file_exists
 
+#[cfg(not(test))]
 fn main() {
     let paths = ["input.txt", "docs"];
     for path in paths.iter().map(|&x| Path::new(x)) {

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -4,6 +4,7 @@ extern crate rand;
 use std::io::timer::sleep;
 use rand::random;
 
+#[cfg(not(test))]
 fn main() {
     let strings = ~[~"Enjoy", ~"Rosetta", ~"Code"];
 


### PR DESCRIPTION
I started cleaning up compilation warnings for dead_code and unused_imports.  When rust files are compiled with `--test`, much of the code and imports aren't used.  An open rust bug about main being dead code is https://github.com/mozilla/rust/issues/13793

We could disable the warnings globally in the makefile, but then you lose the sanity check.  I think the lesser of two evils is to add the config attributes to each file.
