### PR TITLE
tweak .travis.yml to only check new files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
+# Use something that's not 'ruby' so we don't set up things like
+# RVM/bundler/ruby and whatnot. Right now 'rust' isn't a language on
+# travis and it treats unknown languages as ruby
+language: c
+
 before_install:
   - yes | sudo add-apt-repository ppa:hansjorg/rust
   - sudo apt-get update
 install:
   - sudo apt-get install rust-nightly
-script:
-  - make all
+script: |
+  if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then
+    make changed;
+  else
+    make all;
+  fi

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,22 @@ all:
 		echo; \
 	done;
 
+changed:
+	# Make files which changed from master
+	for item in $(git diff --name-only master..HEAD); \
+	do \
+		echo Compiling $$item; \
+		rustc --test $$item -o /tmp/rosetta/$$item || exit; \
+		echo Compiled $$item; \
+		echo; \
+	done;
+	for item in $(git diff --name-only master..HEAD); \
+	do \
+		echo Testing $$item; \
+		$$item; \
+		echo Tested $$item; \
+		echo; \
+	done;
 
 help:
 	# Show this help


### PR DESCRIPTION
If we have a pull request, then only test those files that changed.  That should make it easier to accept pull requests because they won't depend on every other test passing.

I'm new to travis-ci, so I couldn't figure out how to actually test this.
