### PR TITLE
remove cfg attribute which prevents compilation

### DIFF
--- a/src/prime_decomposition.rs
+++ b/src/prime_decomposition.rs
@@ -1,6 +1,5 @@
 // Implements http://rosettacode.org/wiki/Prime_decomposition
 
-#[cfg(not(test))]
 fn factor(mut nb: i32) -> Vec<i32> {
 	let mut result = vec!();
 


### PR DESCRIPTION
I was a tad bit too aggressive in adding attributes.  I'm not sure how I missed this one.  

`factor` is used in tests so we need for both regular compilation and for test compilations.
