### PR TITLE
fix quoting in Makefile target changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all:
 	for item in $(SRCDIR)/*.rs; \
 	do \
 		echo Compiling $$item; \
-		rustc --test $$item -o /tmp/rosetta/$$item || exit; \
+		rustc --test $$item -o $(DSTDIR)/$$item || exit; \
 		echo Compiled $$item; \
 		echo; \
 	done;
@@ -28,19 +28,15 @@ all:
 
 changed:
 	# Make files which changed from master
-	for item in $(git diff --name-only master..HEAD); \
+	for item in $$(git diff --name-only master..HEAD | grep ".rs$$"); \
 	do \
 		echo Compiling $$item; \
 		rustc --test $$item -o /tmp/rosetta/$$item || exit; \
 		echo Compiled $$item; \
 		echo; \
-	done;
-	for item in $(git diff --name-only master..HEAD); \
-	do \
 		echo Testing $$item; \
-		$$item; \
+		$(DSTDIR)/$$item; \
 		echo Tested $$item; \
-		echo; \
 	done;
 
 help:


### PR DESCRIPTION
Now it actually works.  I added some missing dollar signs and filtered it so we don't try to build anything except rust files.

I combined the test code in the same loop because it was easier than storing each file in an array and testing them later.

So, if you want check just your latest commits, make changed now works.
