### PR TITLE
Update create_file to use std::io::FilePermission

### DIFF
--- a/src/create_file.rs
+++ b/src/create_file.rs
@@ -3,9 +3,7 @@
 extern crate libc;
 
 #[cfg(not(test))]
-use std::io::{File, fs};
-#[cfg(not(test))]
-use libc::S_IRWXU;
+use std::io::{File, UserRead, UserWrite, UserExecute, fs};
 
 #[cfg(not(test))]
 fn main () {
@@ -25,8 +23,8 @@ fn main () {
 
     // Create a directory
     // Here we handle a possible error by using the functions provided by result
-    // The second argument is an unsigned int that sets the file permissions
-    let result = fs::mkdir(&Path::new("docs"), S_IRWXU as u32);
+    // The second argument sets the file permissions
+    let result = fs::mkdir(&Path::new("docs"), UserRead|UserWrite|UserExecute);
     if result.is_err() {
         println!("Failed to create a directory: {}", result.err().unwrap());
     }


### PR DESCRIPTION
```
$ rustc -v
rustc 0.11-pre-nightly (e454851 2014-05-08 06:11:37 -0700)
$ make
...
error: src/create_file.rs
 * Build Compilation Output
  src/create_file.rs:29:48: 29:62 error: mismatched types: expected `std::io::FilePermission` but found `u32` (expected struct std::io::FilePermission but found u32)
  src/create_file.rs:29     let result = fs::mkdir(&Path::new("docs"), S_IRWXU as u32);
                                                                       ^~~~~~~~~~~~~~
  error: aborting due to previous error
...
```
