### PR TITLE
add not_tested config attributes

### DIFF
--- a/src/a+b.rs
+++ b/src/a+b.rs
@@ -1,11 +1,11 @@
 // Implements http://rosettacode.org/wiki/A%2BB
+#![cfg(not_tested)]
 
 #![allow(unused_imports)]
 use std::io::stdio::stdin;
 use std::from_str::from_str;
 use std::io::BufferedReader;
 
-#[cfg(not(test))]
 fn main() {
     let input = BufferedReader::new(stdin()).read_line().unwrap();
     let mut words = input.words();

--- a/src/arithmetic_integers.rs
+++ b/src/arithmetic_integers.rs
@@ -1,11 +1,11 @@
 // Implements http://rosettacode.org/wiki/Arithmetic/Integer
+#![cfg(not_tested)]
 
 #![allow(unused_imports)]
 use std::io::stdio::stdin;
 use std::from_str::from_str;
 use std::io::BufferedReader;
 
-#[cfg(not(test))]
 fn main() {
     let input = BufferedReader::new(stdin()).read_line().unwrap();
     let mut words = input.words();

--- a/src/binary_digits.rs
+++ b/src/binary_digits.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Binary_digits
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main() {
     for i in range(0, 16) {
         println!("{:t}", i)

--- a/src/call_foreign_function.rs
+++ b/src/call_foreign_function.rs
@@ -1,19 +1,16 @@
 // Implements http://rosettacode.org/wiki/Call_a_foreign-language_function
+#![cfg(not_tested)]
 
 extern crate libc;
 
-#[cfg(not(test))]
 use libc::c_char;
-#[cfg(not(test))]
 use std::c_str::CString;
 
-#[cfg(not(test))]
 extern "C" {
     // C functions are declared in an `extern "C"` block.
     fn strdup(s: *c_char) -> *c_char;
 }
 
-#[cfg(not(test))]
 fn main() {
     // Create a Rust static string. No allocations.
     let rust_str = "Hello World!";

--- a/src/callback_to_array.rs
+++ b/src/callback_to_array.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Apply_a_callback_to_an_array
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main () {
     let array = [1,2,3,4,5];
 
@@ -11,7 +11,6 @@ fn main () {
     println!("{}", array.iter().map(callback).collect::<Vec<int>>());
 }
 
-#[cfg(not(test))]
 fn callback(val: &int) -> int {
     val + 1
 }

--- a/src/check_file.rs
+++ b/src/check_file.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Check_that_file_exists
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main() {
     let paths = ["input.txt", "docs"];
     for path in paths.iter().map(|&x| Path::new(x)) {

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -1,11 +1,10 @@
 // Implements http://rosettacode.org/wiki/Arithmetic/Complex
+#![cfg(not_tested)]
 
 extern crate num;
 
-#[cfg(not(test))]
 use num::complex::Cmplx;
 
-#[cfg(not(test))]
 fn main() {
     let a = Cmplx::new(-4.0, 5.0);
     let b = Cmplx::new(1.0, 1.0);

--- a/src/concurrent_computing.rs
+++ b/src/concurrent_computing.rs
@@ -1,12 +1,10 @@
 // Implements http://rosettacode.org/wiki/Concurrent_computing
+#![cfg(not_tested)]
 extern crate rand;
 
-#[cfg(not(test))]
 use std::io::timer::sleep;
-#[cfg(not(test))]
 use rand::random;
 
-#[cfg(not(test))]
 fn main() {
     let strings = vec!["Enjoy", "Rosetta", "Code"];
 

--- a/src/count_in_octal.rs
+++ b/src/count_in_octal.rs
@@ -1,11 +1,9 @@
 // Implements http://rosettacode.org/wiki/Count_in_octal
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 use std::u8;
-#[cfg(not(test))]
 use std::iter::range_inclusive;
 
-#[cfg(not(test))]
 fn main() {
     // We count from 0 to 255 (377 in octal)
 	for i in range_inclusive(0, u8::MAX) {

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -1,4 +1,4 @@
 // Implements http://rosettacode.org/wiki/Empty_program
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main(){}

--- a/src/filesize.rs
+++ b/src/filesize.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/File_size
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main() {
     let path_wd = Path::new("input.txt");
     println!("{}", path_wd.stat().unwrap().size);

--- a/src/guess_number.rs
+++ b/src/guess_number.rs
@@ -1,14 +1,11 @@
 // Implements http://rosettacode.org/wiki/Guess_the_number
+#![cfg(not_tested)]
 extern crate rand;
 
-#[cfg(not(test))]
 use rand::{task_rng, Rng};
-#[cfg(not(test))]
 use std::io::stdio::stdin;
-#[cfg(not(test))]
 use std::io::BufferedReader;
 
-#[cfg(not(test))]
 fn main() {
     let mystery_number = task_rng().gen_range(0, 10) + 1;
     println!("Guess my number between 1 and 10");

--- a/src/infinity.rs
+++ b/src/infinity.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Infinity
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main() {
     let inf : f32 = Float::infinity();
     println!("{}", inf);

--- a/src/input_is_terminal.rs
+++ b/src/input_is_terminal.rs
@@ -1,8 +1,8 @@
 // Implements http://rosettacode.org/wiki/Check_input_device_is_a_terminal
+#![cfg(not_tested)]
 
 extern crate libc;
 
-#[cfg(not(test))]
 fn main() {
     let istty = unsafe { libc::isatty(libc::STDIN_FILENO as i32) } != 0;
     if istty {

--- a/src/integer_sequence.rs
+++ b/src/integer_sequence.rs
@@ -1,13 +1,11 @@
 // Implements http://rosettacode.org/wiki/Integer_sequence
+#![cfg(not_tested)]
 
 extern crate num;
 
-#[cfg(not(test))]
 use num::bigint::BigUint;
-#[cfg(not(test))]
 use std::num::One;
 
-#[cfg(not(test))]
 fn main() {
 	let one: BigUint = One::one();
 	let mut i: BigUint = One::one();

--- a/src/loops-for.rs
+++ b/src/loops-for.rs
@@ -1,9 +1,9 @@
 // Implements http://rosettacode.org/wiki/Loops/For
 
-#[cfg(not(test))]
+#![cfg(not_tested)]
+
 use std::iter;
 
-#[cfg(not(test))]
 fn main() {
     for i in iter::range_inclusive(1, 5) {
         for _ in iter::range_inclusive(1, i) {

--- a/src/loops-foreach.rs
+++ b/src/loops-foreach.rs
@@ -1,10 +1,9 @@
 // Implements http://rosettacode.org/wiki/Loops/For
+#![cfg(not_tested)]
 extern crate collections;
 
-#[cfg(not(test))]
 use collections::HashMap;
 
-#[cfg(not(test))]
 fn main() {
     // Iterate through the characters of a string
     let s = "hello, world!";

--- a/src/loops-infinite.rs
+++ b/src/loops-infinite.rs
@@ -1,6 +1,6 @@
 // Implements http://rosettacode.org/wiki/Loops/Infinite
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn main() {
     loop {
         println!("spam");

--- a/src/loops-n-plus-one-half.rs
+++ b/src/loops-n-plus-one-half.rs
@@ -1,9 +1,8 @@
 // Implements http://rosettacode.org/wiki/Loops/N_plus_one_half
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 use std::iter;
 
-#[cfg(not(test))]
 fn main() {
     for i in iter::range_inclusive(1,10) {
         print!("{}", i);

--- a/src/loops-while.rs
+++ b/src/loops-while.rs
@@ -1,6 +1,7 @@
 // Implements http://rosettacode.org/wiki/Loops/While
 
-#[cfg(not(test))]
+#![cfg(not_tested)]
+
 fn main() {
     let mut i = 1024;
     while i > 0 {

--- a/src/output_is_terminal.rs
+++ b/src/output_is_terminal.rs
@@ -1,8 +1,8 @@
 // Implements http://rosettacode.org/wiki/Check_output_device_is_a_terminal
+#![cfg(not_tested)]
 
 extern crate libc;
 
-#[cfg(not(test))]
 fn main() {
     let istty = unsafe { libc::isatty(libc::STDOUT_FILENO as i32) } != 0;
     if istty {

--- a/src/recursion_depth.rs
+++ b/src/recursion_depth.rs
@@ -1,12 +1,11 @@
 // Implements http://rosettacode.org/wiki/Find_limit_of_recursion
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 fn recursion(n: int) {
 	println!("deep: {:d}", n);
 	recursion(n + 1);
 }
 
-#[cfg(not(test))]
 fn main() {
 	recursion(0);
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,11 +1,10 @@
 // Implements http://rosettacode.org/wiki/Set
+#![cfg(not_tested)]
 
 extern crate collections;
 
-#[cfg(not(test))]
 use collections::HashSet;
 
-#[cfg(not(test))]
 fn main() {
     // The first set contains integers from 0 to 7
     let set1 = range(0, 7).collect::<HashSet<int>>();

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -1,10 +1,9 @@
 // Implements http://rosettacode.org/wiki/Hello_world/Standard_error
+#![cfg(not_tested)]
 #![allow(unused_must_use)]
 
-#[cfg(not(test))]
 use std::io;
 
-#[cfg(not(test))]
 fn main() {
     let mut stderr = io::stderr();
     stderr.write(bytes!("Goodbye, World!\n"));

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,8 +1,7 @@
 // Implements http://rosettacode.org/wiki/Generic_swap
-#[cfg(not(test))]
+#![cfg(not_tested)]
 use std::mem::swap;
 
-#[cfg(not(test))]
 fn main() {
   println!("Same type:");
   let mut thing_one = "The First String";


### PR DESCRIPTION
The shiny new build system respects the attribute #![cfg(not_test)].

I ignored all files that didn't make sense to have tests, building on the list in #58.  The primary motivation is we don't have to annotate **every** `fn` with #[cfg(not(test))].

Here's the script I used to convert files.

``` bash
add_not_tested() {
    local source_file="$1"
    sed -i -e '2i#![cfg(not_tested)]' -e '/cfg.*not.*test)/d' "$source_file"
}

for f in "$@"; do
    echo "not testing $f"
    add_not_tested "$f"
done
```
