### PR TITLE
add more meat to main to quell dead-code

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -43,6 +43,13 @@ fn main() {
 
     // Show the element at the top
     println!("{}", stack.peek().unwrap());
+    // Show the element we popped
+    println!("{}", stack.pop().unwrap());
+    if stack.empty() {
+        println!("The stack is empty.")
+    } else {
+        println!("The stack is not empty.")
+    }
 }
 
 #[test]


### PR DESCRIPTION
Use the stack functions in main so rust stops complaining about dead-code.
