### PR TITLE
don't test rename_a_file or webserver

### DIFF
--- a/src/rename_a_file.rs
+++ b/src/rename_a_file.rs
@@ -1,9 +1,8 @@
 // Implements http://rosettacode.org/wiki/Rename_a_file
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 use std::io::fs;
 
-#[cfg(not(test))]
 fn main() {
     fs::rename(&Path::new("input.txt"), &Path::new("output.txt")).unwrap();
     fs::rename(&Path::new("docs"), &Path::new("mydocs")).unwrap();

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,13 +1,10 @@
 // Implements http://rosettacode.org/wiki/Hello_world/Web_server
+#![cfg(not_tested)]
 
-#[cfg(not(test))]
 use std::io::net::tcp::{TcpListener, TcpStream};
-#[cfg(not(test))]
 use std::io::net::ip::{Ipv4Addr, SocketAddr};
-#[cfg(not(test))]
 use std::io::{Acceptor, Listener};
 
-#[cfg(not(test))]
 fn handle_client(mut stream: TcpStream) {
     let response = bytes!(
 "HTTP/1.1 200 OK
@@ -33,7 +30,6 @@ charset=UTF-8
     }
 }
 
-#[cfg(not(test))]
 fn main() {
     let addr = SocketAddr { ip: Ipv4Addr(127, 0, 0, 1), port: 80 };
     let listener = TcpListener::bind(addr).unwrap();


### PR DESCRIPTION
These examples aren't particularly amenable to testing.  We can add them later if we want them.  Right now, these are the only two files breaking the build.
