### PR TITLE
added header and safety note from Sha256 docs

### DIFF
--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -1,3 +1,8 @@
+// Implements http://rosettacode.org/wiki/SHA-256
+
+// note that for now the rustc::util::sha2::Sha256 docs state:
+// This implementation is not intended for external use or for any use where security is
+// important.
 extern crate rustc;
 use rustc::util::sha2::{Sha256, Digest};
 


### PR DESCRIPTION
Added comment with link to Rosetta Code task and disclaimer about safety of sha-256 implementation from the current online docs.
