### PR TITLE
Remove `extern crate collections` from all files.

### DIFF
--- a/src/anagrams.rs
+++ b/src/anagrams.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/Anagrams
 
-extern crate collections;
-
 use std::collections::{HashMap, HashSet};
 use std::str;
 

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Entropy
-extern crate collections;
 
 use std::str::StrSlice;
 use std::collections::hashmap::HashMap;

--- a/src/fibonacci_word.rs
+++ b/src/fibonacci_word.rs
@@ -1,5 +1,4 @@
 // Implements http://rosettacode.org/wiki/Fibonacci_word
-extern crate collections;
 
 use entropy::shannon_entropy;
 use std::iter::range_inclusive;

--- a/src/happy_numbers.rs
+++ b/src/happy_numbers.rs
@@ -1,6 +1,5 @@
 // Implements http://rosettacode.org/wiki/Happy_numbers
 
-extern crate collections;
 use std::collections::treemap::TreeSet;
 #[cfg(not(test))]
 use std::iter::count;

--- a/src/huffman_coding.rs
+++ b/src/huffman_coding.rs
@@ -2,7 +2,6 @@
 //   http://rosettacode.org/wiki/Huffman_coding
 
 extern crate core;
-extern crate collections;
 use std::collections::HashMap;
 use std::collections::priority_queue::PriorityQueue;
 

--- a/src/letter_frequency.rs
+++ b/src/letter_frequency.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/Letter_frequency
 
-extern crate collections;
-
 #[cfg(not(test))]
 use std::io::fs::File;
 #[cfg(not(test))]

--- a/src/loops-foreach.rs
+++ b/src/loops-foreach.rs
@@ -1,6 +1,5 @@
 // Implements http://rosettacode.org/wiki/Loops/For
 // not_tested
-extern crate collections;
 
 use std::collections::HashMap;
 

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -1,7 +1,5 @@
 // Implements http://rosettacode.org/wiki/LZW_compression
 
-extern crate collections;
-
 use std::collections::hashmap::HashMap;
 
 // Compress using LZW

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,8 +1,6 @@
 // Implements http://rosettacode.org/wiki/Set
 // not_tested
 
-extern crate collections;
-
 use std::collections::HashSet;
 
 fn main() {


### PR DESCRIPTION
They're re-exported by `std` crate now; no need to explicitly import the `collections` crate.
