### PR TITLE
removed use of deprecated bytes! macro

### DIFF
--- a/src/md5-implementation.rs
+++ b/src/md5-implementation.rs
@@ -10,12 +10,12 @@ use std::fmt::{Show, Formatter, Result};
 #[cfg(not(test))]
 fn main() {
     let inputs=
-    [bytes!("a"),
-    bytes!("abc"),
-    bytes!("message digest"),
-    bytes!("abcdefghijklmnopqrstuvwxyz"),
-    bytes!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
-    bytes!("12345678901234567890123456789012345678901234567890123456789012345678901234567890")];
+    [b"a",
+    b"abc",
+    b"message digest",
+    b"abcdefghijklmnopqrstuvwxyz",
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    b"12345678901234567890123456789012345678901234567890123456789012345678901234567890"];
 
     for &input in inputs.iter() {
         println!("{}", md5(input));
@@ -170,19 +170,19 @@ fn helper_fns() {
 #[test]
 fn known_hashes() {
     let in_out=
-    [(bytes!(""),
+    [(b"",
         "d41d8cd98f00b204e9800998ecf8427e"),
-    (bytes!("a"),
+    (b"a",
         "0cc175b9c0f1b6a831c399e269772661"),
-    (bytes!("abc"),
+    (b"abc",
         "900150983cd24fb0d6963f7d28e17f72"),
-    (bytes!("message digest"),
+    (b"message digest",
         "f96b697d7cb7938d525a2f31aaf161d0"),
-    (bytes!("abcdefghijklmnopqrstuvwxyz"),
+    (b"abcdefghijklmnopqrstuvwxyz",
         "c3fcd3d76192e4007dfb496cca67e13b"),
-    (bytes!("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"),
+    (b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
         "d174ab98d277d9f5a5611c2c9f419d9f"),
-    (bytes!("12345678901234567890123456789012345678901234567890123456789012345678901234567890"),
+    (b"12345678901234567890123456789012345678901234567890123456789012345678901234567890",
         "57edf4a22be3c955ac49da2e2107b67a")];
 
     for &(i,o) in in_out.iter() {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -15,7 +15,7 @@ static init:[u32,..5] = [0x67452301,0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1
 #[cfg(not(test))]
 fn main() {
 	let mut d = Digest::new();
-	d.write(bytes!("The quick brown fox jumps over the lazy dog")).unwrap();
+	d.write(b"The quick brown fox jumps over the lazy dog").unwrap();
     let sha1=d.sha1();
 
     for h in sha1.iter() {

--- a/src/stderr.rs
+++ b/src/stderr.rs
@@ -6,5 +6,5 @@ use std::io;
 
 fn main() {
     let mut stderr = io::stderr();
-    stderr.write(bytes!("Goodbye, World!\n"));
+    stderr.write(b"Goodbye, World!\n");
 }

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -5,8 +5,8 @@ use std::io::net::tcp::{TcpListener, TcpStream};
 use std::io::{Acceptor, Listener};
 
 fn handle_client(mut stream: TcpStream) {
-    let response = bytes!(
-"HTTP/1.1 200 OK
+    let response =
+b"HTTP/1.1 200 OK
 Content-Type: text/html;
 charset=UTF-8
 
@@ -22,7 +22,7 @@ charset=UTF-8
     <body>
         <h1>Goodbye, world!</h1>
     </body>
-</html>");
+</html>";
     match stream.write(response) {
         Ok(_) => println!("Response sent!"),
         Err(e) => println!("Failed sending response: {}!", e),


### PR DESCRIPTION
the bytes! macro [was deprecated](https://github.com/rust-lang/rust/issues/14881), all instances of bytes!("foo") have been changed to use the new b"foo" literal syntax
