### PR TITLE
to_str() -> to_string()

### DIFF
--- a/src/9_billion_names_of_God_the_integer.rs
+++ b/src/9_billion_names_of_God_the_integer.rs
@@ -29,11 +29,9 @@ fn row(num: uint,  cache: &mut Vec<Vec<BigUint>>) -> String {
     let r = cumu(num,cache);
     let mut returned_string = String::new();
     for i in range(0,num) {
-	let i = *r.get(i+1) - *r.get (i);
-	let z = i.to_str();
-	let y = z.as_slice();
-	returned_string.push_str(y);
-	returned_string.push_str(", ");
+        let i = *r.get(i+1) - *r.get (i);
+        returned_string.push_str(i.to_string().as_slice());
+        returned_string.push_str(", ");
     }
     returned_string
 }

--- a/src/anagrams.rs
+++ b/src/anagrams.rs
@@ -73,16 +73,16 @@ fn main () {
 #[test]
 fn basic_test() {
     // Groups of anagrams
-    let group1: HashSet<String> = vec!["lane".to_str(),
-                                       "neal".to_str(),
-                                       "lean".to_str()]
+    let group1: HashSet<String> = vec!["lane".to_string(),
+                                       "neal".to_string(),
+                                       "lean".to_string()]
                                        .move_iter().collect();
-    let group2: HashSet<String> = vec!["angel".to_str(),
-                                       "angle".to_str(),
-                                       "galen".to_str()]
+    let group2: HashSet<String> = vec!["angel".to_string(),
+                                       "angle".to_string(),
+                                       "galen".to_string()]
                                        .move_iter().collect();
-    let group3: HashSet<String> = vec!["glare".to_str(),
-                                       "large".to_str()]
+    let group3: HashSet<String> = vec!["glare".to_string(),
+                                       "large".to_string()]
                                        .move_iter().collect();
 
     // Prepare the input for the program
@@ -97,7 +97,7 @@ fn basic_test() {
     }
 
     // Here begins the real testing
-    let all_groups = get_anagrams(MemReader::new(words.to_str().as_slice()
+    let all_groups = get_anagrams(MemReader::new(words.to_string().as_slice()
                                                  .bytes().collect()));
     let biggest_groups = get_biggest_groups(&all_groups);
 

--- a/src/iban.rs
+++ b/src/iban.rs
@@ -53,12 +53,12 @@ fn parse_digits(chars: Vec<char>) -> Option<BigInt> {
     // We convert the characters to Ascii to be able to transform the vector in a String directly
     for &c in chars.iter() {
         match c.to_digit(36) {
-            Some(d) => vec.extend(d.to_str().as_slice().chars().map(|c| c.to_ascii())),
+            Some(d) => vec.extend(d.to_string().as_slice().chars().map(|c| c.to_ascii())),
             None    => return None
         };
     }
 
-    from_str(vec.into_str().as_slice())
+    from_str(vec.into_string().as_slice())
 }
 
 fn country_length(country_code: &str) -> Option<uint> {

--- a/src/json.rs
+++ b/src/json.rs
@@ -13,7 +13,7 @@ pub struct Contact {
 #[cfg(not(test))]
 fn main() {
     // Encode contact to json
-    let c = Contact { name: "John".to_str(), city: "Paris".to_str() };
+    let c = Contact { name: "John".to_string(), city: "Paris".to_string() };
     let json = json::encode(&c);
     println!("Encoded: {}", json.as_slice());
 
@@ -25,7 +25,7 @@ fn main() {
 
 #[test]
 fn test_coherence() {
-    let c = Contact { name: "John".to_str(), city: "Paris".to_str() };
+    let c = Contact { name: "John".to_string(), city: "Paris".to_string() };
     assert!(json::decode::<Contact>(json::encode(&c).as_slice()).unwrap() == c);
 }
 
@@ -33,5 +33,5 @@ fn test_coherence() {
 fn test_decode() {
     let json_str = "{\"name\":\"Alan\", \"city\":\"Tokyo\"}";
     let contact: Contact = json::decode(json_str).unwrap();
-    assert!(contact == Contact { name: "Alan".to_str(), city: "Tokyo".to_str() });
+    assert!(contact == Contact { name: "Alan".to_string(), city: "Tokyo".to_string() });
 }

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -82,7 +82,7 @@ fn main() {
 
 #[test]
 fn test_coherence() {
-    for s in range(50000i, 50100).map(|n| n.to_str()) {
+    for s in range(50000i, 50100).map(|n| n.to_string()) {
         assert_eq!(decompress(&compress(s.as_slice())), s);
     }
 }

--- a/src/markov_algorithm.rs
+++ b/src/markov_algorithm.rs
@@ -50,7 +50,8 @@ impl MarkovAlgorithm {
                     let replacement = if stop {line_end.slice_from(1)} else {line_end};
 
                     // add to rules
-                    let new_rule = MarkovRule::new(pattern.to_str(), replacement.to_str(), stop);
+                    let new_rule = MarkovRule::new(pattern.to_string(),
+                                            replacement.to_string(), stop);
                     rules.push(new_rule);
                 }
             }
@@ -63,7 +64,7 @@ impl MarkovAlgorithm {
     pub fn apply(&self, input: &str) -> String {
 
         // get a writable version of the input to work with
-        let mut state = input.to_str();
+        let mut state = input.to_string();
 
         // Don't allow input to be used after this
         drop(input);


### PR DESCRIPTION
to_str() was changed to to_string() everywhere after https://github.com/rust-lang/rust/pull/15493

In iban.rs to_str() still works (and to_string() breaks the program) but I haven't been able to understand why
