### PR TITLE
ported AKS test for primes solution on rosettacode to Rust latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Rosetta Code                                                                    
 [A+B](http://rosettacode.org/wiki/A%2BB)                                                           | [a_plus_b.rs](src/a_plus_b.rs)
 [ABC Problem](http://rosettacode.org/wiki/ABC_Problem)                                             | [abc_problem.rs](src/abc_problem.rs)
 [Ackermann function](http://rosettacode.org/wiki/Ackermann_function)                               | [ackermann_function.rs](src/ackermann_function.rs)
+[AKS test for primes](http://rosettacode.org/wiki/AKS_test_for_primes)                             | [aks_test_for_primes.rs](src/aks_test_for_primes.rs)
 [Almost prime](http://rosettacode.org/wiki/Almost_prime)                                           | [almost_prime.rs](src/almost_prime.rs)
 [Anagrams](http://rosettacode.org/wiki/Anagrams)                                                   | [anagrams.rs](src/anagrams.rs)
 [Apply a callback to an array](http://rosettacode.org/wiki/Apply_a_callback_to_an_array)           | [callback_to_array.rs](src/callback_to_array.rs)

--- a/src/aks_test_for_primes.rs
+++ b/src/aks_test_for_primes.rs
@@ -1,0 +1,64 @@
+// http://rosettacode.org/wiki/AKS_test_for_primes
+#[cfg(not(test))]
+fn main() {
+    for p in range(0u, 8) {
+        println!("{}: {}", p, coefficients(p));
+    }
+
+    for p in range(1u, 51).filter(|&x| is_prime(x)) {
+        print!("{} ", p);
+    }
+}
+
+fn coefficients(p: uint) -> Vec<i64> {
+    if p==0 {
+        vec![1]
+    } else {
+        let mut result = vec![1, -1];
+        let zero = Some(0i64);
+        for _ in range(1u, p) {
+            result = {
+                let a = result.iter().chain(zero.iter());
+                let b = zero.iter().chain(result.iter());
+                a.zip(b).map(|(x, &y)| x-y).collect()
+            };
+        }
+        result
+    }
+}
+
+fn is_prime(p: uint) -> bool {
+    if p<2 {
+        false
+    } else {
+        let mut c = coefficients(p);
+        *c.get_mut(0) -= 1;
+        for i in range(0, c.len()/2) {
+            if (*c.get(i) % (p as i64)) != 0 {
+                return false
+            }
+        }
+        true
+    }
+}
+
+#[test]
+fn test_solution() {
+    let exp_coefficients =  vec![
+                            vec![1i64],
+                            vec![1, -1],
+                            vec![1, -2, 1],
+                            vec![1, -3, 3, -1],
+                            vec![1, -4, 6, -4, 1],
+                            vec![1, -5, 10, -10, 5, -1],
+                            vec![1, -6, 15, -20, 15, -6, 1],
+                            vec![1, -7, 21, -35, 35, -21, 7, -1]];
+    let exp_primes = &[2u, 3, 4, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
+
+    for (i, exp) in exp_coefficients.iter().enumerate() {
+        assert_eq!(*exp, coefficients(i));
+    }
+
+    let primes: Vec<uint> = range(1u, 51).filter(|&i| is_prime(i)).collect();
+    assert_eq!(exp_primes, primes.as_slice());
+}


### PR DESCRIPTION
I had 5 mins after lunch and I did a test of Rust archaeology (as per https://github.com/Hoverbear/rust-rosetta/issues/170). For these "algorithmic" sort of tasks the modernization looks easy enough, but maybe I got a particularly easy one...
