### PR TITLE
Remove unnecessary lifetime annotations.

### DIFF
--- a/src/24_game.rs
+++ b/src/24_game.rs
@@ -89,7 +89,7 @@ struct Lexer<'a> {
 }
 
 impl <'a> Lexer<'a> {
-    fn new(input_str: &'a str) -> Lexer<'a> {
+    fn new(input_str: &str) -> Lexer {
         Lexer { input_str: input_str, offset: 0u }
     }
 
@@ -204,7 +204,7 @@ struct Parser<'a> {
 }
 
 impl <'a> Parser<'a> {
-    fn new(input_str: &'a str) -> Parser<'a> {
+    fn new(input_str: &str) -> Parser {
         Parser {
             operators:  Vec::new(),
             operands:   Vec::new(),

--- a/src/9_billion_names_of_God_the_integer.rs
+++ b/src/9_billion_names_of_God_the_integer.rs
@@ -6,7 +6,7 @@ use num::bigint::BigUint;
 use std::string::String;
 use std::cmp::min;
 
-fn cumu<'a>(num: uint, cache: &'a mut Vec<Vec<BigUint>>) -> &'a Vec<BigUint> {
+fn cumu(num: uint, cache: &mut Vec<Vec<BigUint>>) -> &Vec<BigUint> {
     let len = cache.len();
     for l in range(len, num+1) {
         let initial_value:BigUint = from_str("0").unwrap();

--- a/src/dot_product.rs
+++ b/src/dot_product.rs
@@ -3,7 +3,7 @@
 use std::ops::{Add, Mul};
 use std::num::Zero;
 
-fn dotp<'a, T:Add<T, T> + Mul<T, T> + Zero + Copy>(this: &'a [T], other: &'a [T]) -> T {
+fn dotp<T:Add<T, T> + Mul<T, T> + Zero + Copy>(this: &[T], other: &[T]) -> T {
   assert!(this.len() == other.len(), "The dimensions must be equal");
 
   let zero : T = Zero::zero();

--- a/src/four_bit_adder.rs
+++ b/src/four_bit_adder.rs
@@ -51,7 +51,7 @@ impl fmt::Show for Nibble {
 
 // We implement Deref so we can index the Nibble easily
 impl<'a> Deref<[bool,.. 4]> for Nibble {
-  fn deref<'a>(&'a self) -> &'a [bool,.. 4] {
+  fn deref(&self) -> &[bool,.. 4] {
     let Nibble(ref inner) = *self;
     inner
   }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -22,7 +22,7 @@ impl<T> Stack<T> {
     }
 
     // Returns a reference of the element at the top of the stack
-    fn peek<'r>(&'r self) -> Option<&'r T> {
+    fn peek(&self) -> Option<&T> {
         self.vec.last()
     }
 


### PR DESCRIPTION
A patch to make this possible just landed in Rust master a few hours ago.
