### PR TITLE
migrated bitwise operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Rosetta Code                                                                    
 [Averages/Mean angle](http://rosettacode.org/wiki/Averages/Mean_angle)                             | [averages_mean_angle.rs](src/averages_mean_angle.rs)
 [Balanced brackets](http://rosettacode.org/wiki/Balanced_brackets)                                 | [balanced_brackets.rs](src/balanced_brackets.rs)
 [Binary digits](http://rosettacode.org/wiki/Binary_digits)                                         | [Binary_digits.rs](src/binary_digits.rs)
+[Binary search](http://rosettacode.org/wiki/Binary_search)                                         | [binary_search.rs](src/binary_search.rs)
+[Bitwise operations](http://rosettacode.org/wiki/Bitwise_operations)                               | [bitwise_operations.rs](src/bitwise_operations.rs)
 [Bubble sort](http://rosettacode.org/wiki/Sorting_algorithms/Bubble_sort)                          | [bubble_sort.rs](src/bubble_sort.rs)
 [Call a foreign-language function](http://rosettacode.org/wiki/Call_a_foreign-language_function)   | [call_foreign_function.rs](src/call_foreign_function.rs)
 [Check input device is a terminal](http://rosettacode.org/wiki/Check_input_device_is_a_terminal)   | [input_is_terminal.rs](src/input_is_terminal.rs)

--- a/src/bitwise_operations.rs
+++ b/src/bitwise_operations.rs
@@ -1,0 +1,14 @@
+// http://rosettacode.org/wiki/Bitwise_operations
+// not_tested
+fn main() {
+    let a: u8 = 105;
+    let b: u8 = 91;
+    println!("a      = {:0>8t}", a);
+    println!("b      = {:0>8t}", b);
+    println!("a | b  = {:0>8t}", a | b);
+    println!("a & b  = {:0>8t}", a & b);
+    println!("a ^ b  = {:0>8t}", a ^ b);
+    println!("!a     = {:0>8t}", !a);
+    println!("a << 3 = {:0>8t}", a >> 3);
+    println!("a >> 3 = {:0>8t}", a << 3);
+}


### PR DESCRIPTION
Migrated bitwise operations from the rosettacode. 
Added binary search to readme (I had forgotten that one, sorry).
ref https://github.com/Hoverbear/rust-rosetta/issues/170
