### PR TITLE
hamming alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Rosetta Code                                                                    
 [Hailstone sequence](http://rosettacode.org/wiki/Hailstone_sequence)                               | [hailstone.rs](src/hailstone.rs)
 [Hamming numbers](http://rosettacode.org/wiki/Hamming_numbers)                                     | [hamming_numbers.rs](src/hamming_numbers.rs), [hamming_numbers_alt.rs](src/hamming_numbers_alt.rs)
 [Happy numbers](http://rosettacode.org/wiki/Happy_numbers)                                         | [happy_numbers.rs](src/happy_numbers.rs)
-[Harshad or Niven series]http://rosettacode.org/wiki/Harshad_or_Niven_series                       | [harshad_or_niven_series.rs](src/harshad_or_niven_series.rs)
+[Harshad or Niven series](http://rosettacode.org/wiki/Harshad_or_Niven_series)                       | [harshad_or_niven_series.rs](src/harshad_or_niven_series.rs)
 [HTTP](http://rosettacode.org/wiki/HTTP)                                                           | [http.rs](src/http.rs)
 [Huffman encoding](http://rosettacode.org/wiki/Huffman_coding)                                     | [huffman_coding.rs](src/huffman_coding.rs)
 [IBAN](http://rosettacode.org/wiki/IBAN)                                                           | [iban.rs](src/iban.rs)

--- a/src/hamming_numbers.rs
+++ b/src/hamming_numbers.rs
@@ -1,74 +1,85 @@
-// Implements http://rosettacode.org/wiki/Hamming_numbers
-// Port of one of the scala solutions
+// http://rosettacode.org/wiki/Hamming_numbers
 extern crate num;
-
-use num::bigint::BigUint;
+use num::bigint::{BigUint, ToBigUint};
 use std::cmp::min;
-use std::num::One;
+use std::num::{One, one};
 use std::collections::{RingBuf, Deque};
 
-// Helper function to avoid repeating `FromPrimitive::from_int(i).unwrap()`
-// for every BigUint creation.
-fn int_to_biguint(i: int) -> BigUint {
-    FromPrimitive::from_int(i).unwrap()
-}
-
+// needed because hamming_numbers_alt uses this as a library
+#[allow(dead_code)]
 #[cfg(not(test))]
 fn main() {
-    let hamming = Hamming::new(128);
+    // capacity of the queue currently needs to be a power of 2 because of a bug with RingBuf
+    let hamming : Hamming<BigUint> = Hamming::new(128);
 
-    for (idx, h) in hamming.enumerate() {
+    for (idx, h) in hamming.enumerate().take(1_000_000) {
         match idx + 1 {
-            1..20 => print!("{} ", h),
-            i @ 1691 | i @ 1000000 => println!("\n{}th number: {}", i, h),
-            i if i < 1000000 =>  continue ,
-            _ => break
+            1..20 => print!("{} ", h.to_biguint().unwrap()),
+            i @ 1691 | i @ 1000000 => println!("\n{}th number: {}", i, h.to_biguint().unwrap()),
+            _ =>  continue
         }
     }
+}
+//representing a Hamming number as a BigUint
+impl HammingNumber for BigUint {
+    // returns the multipliers 2, 3 and 5 in the representation for the HammingNumber
+    fn multipliers()-> (BigUint, BigUint, BigUint) {
+        (2u.to_biguint().unwrap(),
+        3u.to_biguint().unwrap(),
+        5u.to_biguint().unwrap())
+    }
+}
+
+/// representation of a Hamming number
+/// allows to abstract on how the hamming number is stored
+/// i.e. as BigUint directly or just as the powers of 2, 3 and 5 used to build it
+pub trait HammingNumber : Eq + Ord + ToBigUint + Mul<Self, Self> + One {
+    fn multipliers() -> (Self, Self, Self);
 }
 
 /// Hamming numbers are multiples of 2, 3 or 5.
 ///
 /// We keep them on three queues and extract the lowest (leftmost) value from
 /// the three queues at each iteration.
-pub struct Hamming {
+pub struct Hamming<T> {
     // Using a RingBuf as a queue, push to the back, pop from the front
-    q2: RingBuf<BigUint>,
-    q3: RingBuf<BigUint>,
-    q5: RingBuf<BigUint>
+    q2: RingBuf<T>,
+    q3: RingBuf<T>,
+    q5: RingBuf<T>
 }
 
-impl Hamming {
+impl<T: HammingNumber> Hamming<T> {
     /// Static constructor method
     /// `n` initializes the capacity of the queues
-    fn new(n: uint) -> Hamming {
+    pub fn new(n: uint) -> Hamming<T> {
         let mut h = Hamming {
             q2: RingBuf::with_capacity(n),
             q3: RingBuf::with_capacity(n),
             q5: RingBuf::with_capacity(n)
         };
 
-        h.q2.push(One::one());
-        h.q3.push(One::one());
-        h.q5.push(One::one());
+        h.q2.push(one());
+        h.q3.push(one());
+        h.q5.push(one());
 
         h
     }
 
     /// Pushes the next multiple of `n` (x2, x3, x5) to the queues
-    fn enqueue(&mut self, n: &BigUint) {
-        self.q2.push(n * int_to_biguint(2));
-        self.q3.push(n * int_to_biguint(3));
-        self.q5.push(n * int_to_biguint(5));
+    pub fn enqueue(&mut self, n: &T) {
+        let (two, three, five) = HammingNumber::multipliers();
+        self.q2.push(*n * two);
+        self.q3.push(*n * three);
+        self.q5.push(*n * five);
     }
 }
 
 // Implements the `Iterator` trait, so we can generate Hamming numbers lazily
-impl Iterator<BigUint> for Hamming {
+impl<T: HammingNumber> Iterator<T> for Hamming<T> {
     // The core of the work is done in the `next` method.
     // We check which of the 3 queues has the lowest candidate and extract it
     // as the next Hamming number.
-    fn next(&mut self) -> Option<BigUint> {
+    fn next(&mut self) -> Option<T> {
         // Return `pop_targets` so the borrow from `front()` will be finished
         let (two, three, five) = match (self.q2.front(),
                                         self.q3.front(),
@@ -96,32 +107,40 @@ impl Iterator<BigUint> for Hamming {
 
 #[test]
 fn create() {
-    let mut h = Hamming::new(5);
-    h.q2.push(int_to_biguint(1));
-    h.q2.push(int_to_biguint(2));
-    h.q2.push(int_to_biguint(4));
+    let mut h = Hamming::<BigUint>::new(5);
+    h.q2.push(one::<BigUint>());
+    h.q2.push(one::<BigUint>() * 3u.to_biguint().unwrap());
 
-    assert_eq!(h.q2.pop_front().unwrap(), One::one());
+    assert_eq!(h.q2.pop_front().unwrap(), one::<BigUint>());
 }
 
 #[test]
 fn try_enqueue() {
-    let mut h = Hamming::new(5);
+    let mut h = Hamming::<BigUint>::new(5);
+    let (two, three, five) = HammingNumber::multipliers();
+    h.enqueue(&one::<BigUint>());
+    h.enqueue(&(&one::<BigUint>() * two));
 
-    h.enqueue(&int_to_biguint(1));
-    h.enqueue(&int_to_biguint(2));
-    h.enqueue(&int_to_biguint(3));
-
-    assert_eq!(h.q2.pop_front().unwrap(), int_to_biguint(1));
-    assert_eq!(h.q3.pop_front().unwrap(), int_to_biguint(1));
-    assert_eq!(h.q5.pop_front().unwrap(), int_to_biguint(1));
-    assert_eq!(h.q2.pop_front().unwrap(), int_to_biguint(2));
-    assert_eq!(h.q3.pop_front().unwrap(), int_to_biguint(3));
-    assert_eq!(h.q5.pop_front().unwrap(), int_to_biguint(5));
+    assert!(h.q2.pop_front().unwrap() == one::<BigUint>());
+    assert!(h.q3.pop_front().unwrap() == one::<BigUint>());
+    assert!(h.q5.pop_front().unwrap() == one::<BigUint>());
+    assert!(h.q2.pop_front().unwrap() == one::<BigUint>() * two);
+    assert!(h.q3.pop_front().unwrap() == one::<BigUint>() * three);
+    assert!(h.q5.pop_front().unwrap() == one::<BigUint>() * five);
  }
 
 #[test]
 fn hamming_iter() {
-    let mut hamming = Hamming::new(20);
-    assert_eq!(hamming.nth(19), Some(int_to_biguint(36)));
+    let mut hamming = Hamming::<BigUint>::new(20);
+    assert!(hamming.nth(19).unwrap().to_biguint() == 36u.to_biguint());
+}
+
+#[test]
+fn hamming_iter_1million() {
+    let mut hamming = Hamming::<BigUint>::new(128);
+    // one-million-th hamming number has index 999_999 because indexes are zero-based
+    assert_eq!(hamming.nth(999_999).unwrap().to_biguint(),
+        from_str(
+        "519312780448388736089589843750000000000000000000000000000000000000000000000000000000")
+        );
 }

--- a/src/hamming_numbers_alt.rs
+++ b/src/hamming_numbers_alt.rs
@@ -1,0 +1,146 @@
+// Implements http://rosettacode.org/wiki/Hamming_numbers
+// alternate version: uses a more efficient representation of Hamming numbers:
+// instead of storing them as BigUint directly, it stores the three exponents
+// i, j and k for 2^i * 3^j * 5 ^k and the logarithm of the number for comparisons
+extern crate num;
+
+use hamming_numbers::{Hamming, HammingNumber};
+use std::num::{One, pow};
+use num::bigint::{BigUint, ToBigUint};
+
+mod hamming_numbers;
+
+#[cfg(not(test))]
+fn main() {
+    // capacity of the queue currently needs to be a power of 2 because of a bug with RingBuf
+    let hamming : Hamming<HammingTriple> = Hamming::new(128);
+
+    for (idx, h) in hamming.enumerate().take(1_000_000) {
+        match idx + 1 {
+            1..20 => print!("{} ", h.to_biguint().unwrap()),
+            i @ 1691 | i @ 1_000_000 => println!("\n{}th number: {}", i, h.to_biguint().unwrap()),
+            _ =>  continue
+        }
+    }
+}
+
+// we store these to calculate the ln of a hamming number
+pub static LN_2: f64 = 0.693147180559945309417232121458176568075500134360255254120680_f64;
+pub static LN_3: f64 = 1.098612288668109691395245236922525704647490557822749451734694_f64;
+pub static LN_5: f64 = 1.609437912434100374600759333226187639525601354268517721912647_f64;
+
+// more space-efficient representation of a Hamming number.
+// A Hamming number is 2^i * 3^j * 5^k;
+// instead of storing it directly as a BigUint
+// we store the powers i, j and k and calculate the
+// result as a BigUint only when we need it.
+// we also store the logarithm for quicker comparisons, using this property
+// of logarithms: ln(2^i * 3^j * 5^k) = i*ln2 + j*ln3 + k*ln5
+#[deriving(Show)]
+pub struct HammingTriple {
+    pow_2: uint,
+    pow_3: uint,
+    pow_5: uint,
+    ln: f64
+}
+
+impl Mul<HammingTriple, HammingTriple> for HammingTriple {
+    fn mul(&self, other: &HammingTriple) -> HammingTriple {
+        HammingTriple{ pow_2: self.pow_2 + other.pow_2,
+            pow_3: self.pow_3 + other.pow_3,
+            pow_5: self.pow_5 + other.pow_5,
+            ln: self.ln + other.ln }
+    }
+}
+
+impl One for HammingTriple {
+    // 1 as an HammingNumber is 2^0 * 3^0 * 5^0
+    // ln(1) = 0
+    fn one() -> HammingTriple {
+        HammingTriple::new(0, 0, 0)
+    }
+}
+
+impl HammingNumber for HammingTriple {
+    fn multipliers() -> (HammingTriple, HammingTriple, HammingTriple) {
+        (HammingTriple { pow_2: 1, pow_3: 0, pow_5: 0, ln: LN_2 },
+        HammingTriple { pow_2: 0, pow_3: 1, pow_5: 0, ln: LN_3 },
+        HammingTriple { pow_2: 0, pow_3: 0, pow_5: 1, ln: LN_5 })
+    }
+}
+
+impl ToBigUint for HammingTriple {
+   // calculate the value as a BigUint
+    fn to_biguint(&self) -> Option<BigUint> {
+        Some(pow(2u.to_biguint().unwrap(), self.pow_2) *
+        pow(3u.to_biguint().unwrap(), self.pow_3) *
+        pow(5u.to_biguint().unwrap(), self.pow_5))
+    }
+}
+
+impl HammingTriple {
+    fn new(pow_2: uint, pow_3: uint, pow_5: uint) -> HammingTriple {
+        HammingTriple {
+            pow_2: pow_2,
+            pow_3: pow_3,
+            pow_5: pow_5,
+            ln: (pow_2 as f64) * LN_2 + (pow_3 as f64) * LN_3 + (pow_5 as f64) * LN_5
+        }
+    }
+}
+
+impl Clone for HammingTriple {
+    /// Return a deep copy of the value.
+    #[inline]
+    fn clone(&self) -> HammingTriple { *self }
+}
+
+impl PartialEq for HammingTriple {
+    fn eq(&self, other: &HammingTriple) -> bool {
+        self.pow_2 == other.pow_2 &&
+        self.pow_3 == other.pow_3 &&
+        self.pow_5 == other.pow_5
+    }
+}
+
+impl Eq for HammingTriple {}
+
+impl PartialOrd for HammingTriple {
+    fn partial_cmp(&self, other: &HammingTriple) -> Option<Ordering> {
+        if self == other { Some(Equal) }
+        else if self.pow_2 >= other.pow_2 && self.pow_3 >= other.pow_3 &&
+            self.pow_5 >= other.pow_5 { Some(Greater) }
+        else if self.pow_2 <= other.pow_2 && self.pow_3 <= other.pow_3 &&
+            self.pow_5 <= other.pow_5 { Some(Less) }
+        else if self.ln > other.ln { Some(Greater) }
+        else if self.ln < other.ln { Some(Less) }
+        else { None }
+    }
+}
+
+impl Ord for HammingTriple {
+    fn cmp(&self, other: &HammingTriple) -> Ordering {
+        // as a last resort we need to calculate the BigUint values and compare them.
+        // This should be rare. The reason is that for very big values floating point precision
+        // could make hamming_1.ln == hamming_2.ln even if the two numbers are actually different
+        self.partial_cmp(other).unwrap_or_else( ||
+            self.to_biguint().unwrap().cmp(&other.to_biguint().unwrap())
+        )
+    }
+}
+
+#[test]
+fn hamming_iter() {
+    let mut hamming = Hamming::<HammingTriple>::new(20);
+    assert!(hamming.nth(19).unwrap().to_biguint() == 36u.to_biguint());
+}
+
+#[test]
+fn hamming_iter_1million() {
+    let mut hamming = Hamming::<HammingTriple>::new(128);
+    // one-million-th hamming number has index 999_999 because indexes are zero-based
+    assert_eq!(hamming.nth(999_999).unwrap().to_biguint(),
+        from_str(
+        "519312780448388736089589843750000000000000000000000000000000000000000000000000000000")
+        );
+}


### PR DESCRIPTION
re-added the Hamming alternative (including @Ryman's modifications in https://github.com/Hoverbear/rust-rosetta/pull/192 ).

The part I'm not very happy about is the HammingNumber trait.

``` rust
pub trait HammingNumber : Eq + Ord + Send + ToBigUint {
    fn times_2(&self)-> Self;
    fn times_3(&self)-> Self;
    fn times_5(&self)-> Self;
    fn one() -> Self;
}
```

what I'd like to do ideally is implementing `num::Mul` (instead of times_2, 3 and 5) and then `num::One` (that depends on Mul).
However this would bloat code a lot as:
1. I'd have to newtype BigUint (as I can't re-implement `Mul<Biguint,Biguint>`)
2. I'd have to implement Mul<HammingBigUint, HammingBigUint> for any multiplication between HammingNumbers even though I only need to multiply them by 2, 3 or 5 or I would need to make the the multiplication fail for any value other than 2, 3 or 5, which seems.... inelegant.
