### PR TITLE
implemented Roots of unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Rosetta Code                                                                    
 [Rename a file](http://rosettacode.org/wiki/Rename_a_file)                                         | [rename_a_file.rs](src/rename_a_file.rs)
 [Repeat a string](http://rosettacode.org/wiki/Repeat_a_string)                                     | [repeat_str.rs](src/repeat_str.rs)
 [Reverse words in a string](http://rosettacode.org/wiki/Reverse_words_in_a_string)                 | [reverse_words_str.rs](src/reverse_words_str.rs)
+[Roots of unity](http://rosettacode.org/wiki/Roots_of_unity)                                        | [roots_of_unity.rs](src/roots_of_unity.rs)
 [Rot-13](http://rosettacode.org/wiki/Rot-13)                                                       | [rot13.rs](src/rot13.rs)
 [Run-length encoding](http://rosettacode.org/wiki/Run-length_encoding)                             | [run_length_encoding.rs](src/run_length_encoding.rs)
 [Self-describing numbers](http://rosettacode.org/wiki/Self-describing_numbers)                     | [self-describing_numbers.rs](src/self-describing_numbers.rs)

--- a/src/roots_of_unity.rs
+++ b/src/roots_of_unity.rs
@@ -1,0 +1,31 @@
+// http://rosettacode.org/wiki/Roots_of_unity
+extern crate num;
+use num::complex::{Complex, Complex32};
+use std::f32::consts;
+
+#[cfg(not(test))]
+fn main() {
+    let degree = 3u;
+
+    for root in roots_of_unity(degree).iter() {
+        println!("{}", root);
+    }
+}
+
+fn roots_of_unity(degree: uint) -> Vec<Complex32> {
+    range(0, degree).map(|el|
+        Complex::<f32>::from_polar(&1f32, &(2f32 * consts::PI * (el as f32) / (degree as f32))))
+        .collect::<Vec<Complex32>>()
+}
+
+#[test]
+fn test_result() {
+    let expected = vec![ Complex::new(1f32, 0.),
+        Complex::new(-0.5, 0.866025),
+        Complex::new(-0.5, -0.866025)
+    ];
+
+    for (root, &exp) in roots_of_unity(3u).iter().zip(expected.iter()) {
+        assert!((root - exp).norm() < 1e-6);
+    }
+}


### PR DESCRIPTION
Added roots of unity.

I wanted to do what @Ryman did in https://github.com/Ryman/rust-rosetta/commit/dfa44277b6f1b04592b8301c275e12f4531fb739 but when I tried to return directly the iterator I got in trouble with lifetimes, so I had to collect results in a vector.

i.e. I would have liked to write this (in case someone else can fix it):
http://is.gd/EidM34

``` rust
extern crate num;
use num::complex::{Complex, Complex32};
use std::f32::consts;
use std::iter::{Range, Map};

type RootsIterator<'a> = Map<'a, uint, Complex32, Range<uint>>;

fn main() {
    let degree = 3u;

   for root in roots_of_unity(degree) {
        println!("{}", root);
    }
}

fn roots_of_unity<'a>(degree: uint) -> RootsIterator<'a> {
    range(0, degree).map(|el|
        Complex::<f32>::from_polar(&1f32, &(2. * consts::PI * (el as f32) / (degree as f32))))
}
```
