### PR TITLE
fix build

### DIFF
--- a/src/aks_test_for_primes.rs
+++ b/src/aks_test_for_primes.rs
@@ -53,12 +53,12 @@ fn test_solution() {
                             vec![1, -5, 10, -10, 5, -1],
                             vec![1, -6, 15, -20, 15, -6, 1],
                             vec![1, -7, 21, -35, 35, -21, 7, -1]];
-    let exp_primes = &[2u, 3, 4, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
+    let exp_primes = [2u, 3, 4, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47];
 
     for (i, exp) in exp_coefficients.iter().enumerate() {
         assert_eq!(*exp, coefficients(i));
     }
 
     let primes: Vec<uint> = range(1u, 51).filter(|&i| is_prime(i)).collect();
-    assert_eq!(exp_primes, primes.as_slice());
+    assert_eq!(exp_primes.as_slice(), primes.as_slice());
 }

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -26,7 +26,7 @@ fn add_to_array() {
 	// Immutable adding.
 	let b_vec = vec![2, 3, 4];
 	let c_vec = a_vec.append(b_vec.as_slice());
-	assert_eq!(c_vec.as_slice(), &[1, 2, 3, 4]);
+	assert_eq!(c_vec.as_slice(), [1, 2, 3, 4].as_slice());
 }
 
 #[test]
@@ -38,5 +38,5 @@ fn retrieving_from_array() {
 	// A full copy of the vector, but mutable.
 	let mut mut_vec = a_vec.clone();
 	assert_eq!(mut_vec.pop(), Some(3));
-	assert_eq!(mut_vec.as_slice(), &[1, 2]);
+	assert_eq!(mut_vec.as_slice(), [1, 2].as_slice());
 }

--- a/src/callback_to_array.rs
+++ b/src/callback_to_array.rs
@@ -2,8 +2,8 @@
 // not_tested
 
 fn main () {
-    let array = &[1,2,3,4,5];
-    println!("{}", array);
+    let array = [1,2,3,4,5];
+    println!("{}", array.as_slice());
 
     println!("{}", array.iter()
                         // The map does not modify the original array.

--- a/src/equilibrium_index.rs
+++ b/src/equilibrium_index.rs
@@ -21,9 +21,9 @@ fn equilibrium_indices<T: Add<T, T> + Sub<T, T> + Eq + Zero + Copy>(v: &[T]) -> 
 
 #[cfg(not(test))]
 fn main() {
-    let v = &[-7i, 1, 5, 2, -4, 3, 0];
+    let v = [-7i, 1, 5, 2, -4, 3, 0];
     let indices = equilibrium_indices(v);
-    println!("Equilibrium indices for {} are: {}", v, indices);
+    println!("Equilibrium indices for {} are: {}", v.as_slice(), indices);
 }
 
 #[test]

--- a/src/hailstone.rs
+++ b/src/hailstone.rs
@@ -65,8 +65,8 @@ fn main() {
 fn test_27() {
     let seq = Hailstone::new(27).collect::<Vec<uint>>();
 
-    assert_eq!(seq.slice(0, 4), &[27, 82, 41, 124]);
-    assert_eq!(seq.slice(seq.len() - 4, seq.len()), &[8, 4, 2, 1]);
+    assert_eq!(seq.slice(0, 4), [27, 82, 41, 124].as_slice());
+    assert_eq!(seq.slice(seq.len() - 4, seq.len()), [8, 4, 2, 1].as_slice());
 }
 
 #[test]

--- a/src/lzw.rs
+++ b/src/lzw.rs
@@ -90,6 +90,6 @@ fn test_coherence() {
 #[test]
 fn test_example() {
     let original = "TOBEORNOTTOBEORTOBEORNOT";
-    assert_eq!(compress(original).as_slice(), &[84i, 79, 66, 69, 79, 82, 78, 79, 84,
-                                                256, 258, 260, 265, 259, 261, 263]);
+    assert_eq!(compress(original).as_slice(), [84i, 79, 66, 69, 79, 82, 78, 79, 84,
+                                                256, 258, 260, 265, 259, 261, 263].as_slice());
 }

--- a/src/perfect_numbers.rs
+++ b/src/perfect_numbers.rs
@@ -16,7 +16,7 @@ fn main() {
 fn test_first_four() {
   let nums = range(2, 10_000u).filter(|&n| perfect_number(n))
                               .collect::<Vec<uint>>();
-  assert_eq!(nums.as_slice(), &[6, 28, 496, 8128]);
+  assert_eq!(nums.as_slice(), [6, 28, 496, 8128].as_slice());
 }
 
 #[test]


### PR DESCRIPTION
Should fix the build that was breaking with some errors like:

```
error: failed to find an implementation of trait core::fmt::Show for [int,.. 16]
```

the issue is that with the ongoing work on DST,  `&[1, 2]` (creating a vector and taking a slice) has changed from returning a `&[int]` to returning a `&[int,..2]` and fixed sized vectors don't implement traits like Show or Eq.

Fix is changing from code like:

``` rust
let vec = &[1, 2];
do_something_witth(vec);
```

to

``` rust
let vec = [1, 2];
do_something_witth(vec.as_slice());
```
