### PR TITLE
some io methods moved to std::io::fs::PathExtensions

### DIFF
--- a/src/check_file.rs
+++ b/src/check_file.rs
@@ -1,5 +1,6 @@
 // Implements http://rosettacode.org/wiki/Check_that_file_exists
 // not_tested
+use std::io::fs::PathExtensions;
 
 fn main() {
     let paths = ["input.txt", "docs"];

--- a/src/create_file.rs
+++ b/src/create_file.rs
@@ -5,6 +5,8 @@ extern crate libc;
 use std::io;
 use std::io::{File, fs};
 
+#[cfg(test)] use std::io::fs::PathExtensions;
+
 #[cfg(not(test))]
 fn main () {
     // Create a new file.  We get a Result object from

--- a/src/filesize.rs
+++ b/src/filesize.rs
@@ -1,5 +1,6 @@
 // Implements http://rosettacode.org/wiki/File_size
 // not_tested
+use std::io::fs::PathExtensions;
 
 fn main() {
     let path_wd = Path::new("input.txt");


### PR DESCRIPTION
added a "use" to bring the trait in scope. Fixes build errors on a few tasks that use IO
