### PR TITLE
fix infinite loop

### DIFF
--- a/src/24_game.rs
+++ b/src/24_game.rs
@@ -137,8 +137,10 @@ impl <'a> Iterator<Token> for Lexer<'a> {
             // Found a digit. if there are others, transform them to `uint`
             Some((mut offset, ch)) if UnicodeChar::is_numeric(ch) => {
                 let mut val = Char::to_digit(ch, 10).unwrap();
+                let mut more = false;
 
                 for (idx, ch) in remaining {
+                    more = true;
                     if UnicodeChar::is_numeric(ch) {
                         let digit = Char::to_digit(ch, 10).unwrap();
                         val = val * 10 + digit;
@@ -147,7 +149,9 @@ impl <'a> Iterator<Token> for Lexer<'a> {
                         break;
                     }
                 }
-
+                if !more {
+                    offset = 1;
+                }
                 (Some(Token::Int(val)), offset)
             },
             // found non-digit, try transforming it to the corresponding token
@@ -393,5 +397,7 @@ mod test {
     fn try_check_values() {
         let m = &mut [1, 2, 3, 4];
         assert!(check_values(m, "1+3 -(4/2)"));
+        // new testcase for #314
+        assert!(check_values(m, "1+2+3+4"));
     }
 }


### PR DESCRIPTION
for expression 

``` shell
"1+2+3+4"
```

(expression ends with a digit).
if 4 is the last token, the 

``` python
for (idx, ch) in remaining {
```

will never enter in, and offset will always be 0, this cause the `self.offset` never changed.

so when run 24_game in interactive mode, it will enter infinite loop and got no answer.

check_values will got in infinite loop, this patch fix it.
this patch seems tedious, but I haven't got better solution. 
