### PR TITLE
nitpick minor typo

### DIFF
--- a/tasks/rep-string/src/main.rs
+++ b/tasks/rep-string/src/main.rs
@@ -1,5 +1,5 @@
 fn main() {
-    for a_slice in vec![
+    for a_slice in &[
         "1001110011",
         "1110111011",
         "0010010010",

--- a/tasks/rep-string/src/main.rs
+++ b/tasks/rep-string/src/main.rs
@@ -1,26 +1,25 @@
 fn main() {
-    let strings = vec![
-        String::from("1001110011"),
-        String::from("1110111011"),
-        String::from("0010010010"),
-        String::from("1010101010"),
-        String::from("1111111111"),
-        String::from("0100101101"),
-        String::from("0100100"),
-        String::from("101"),
-        String::from("11"),
-        String::from("00"),
-        String::from("1"),
-    ];
-    for string in strings {
-        match rep_string(&string) {
-            Some(rep_string) => println!(
+    for a_slice in vec![
+        "1001110011",
+        "1110111011",
+        "0010010010",
+        "1010101010",
+        "1111111111",
+        "0100101101",
+        "0100100",
+        "101",
+        "11",
+        "00",
+        "1",
+    ] {
+        match rep_string(&a_slice) {
+            Some(repeated) => println!(
                 "Longest rep-string for '{}' is '{}' ({} chars)",
-                string,
-                rep_string,
-                rep_string.len(),
+                a_slice,
+                repeated,
+                repeated.len(),
             ),
-            None => println!("No rep-string found for '{}'", string),
+            None => println!("No rep-string found for '{}'", a_slice),
         };
     }
 }

--- a/tasks/rep-string/src/main.rs
+++ b/tasks/rep-string/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     for string in strings {
         match rep_string(&string) {
             Some(rep_string) => println!(
-                "Longuest rep-string for '{}' is '{}' ({} chars)",
+                "Longest rep-string for '{}' is '{}' ({} chars)",
                 string,
                 rep_string,
                 rep_string.len(),


### PR DESCRIPTION
Meandered into  [tasks/rep-string/src/main.rs](https://github.com/rust-rosetta/rust-rosetta/blob/1642e32e5872c0a43f17804768c159059f8d83ab/tasks/rep-string/src/main.rs)
- fix a typo
- remove needless `String::from` creations and make some style changes

@Polochon-street nice work! I saw your comment in a92d8381456ba038c554785b91bd03656add953b and figured I'd PR :smile: 
If you want we could take a functional programming approach for some of that logic too.