### PR TITLE
Add Hickerson series of almost integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "decimal"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ord_subset 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "decode"
 version = "0.1.0"
 
@@ -1328,6 +1341,14 @@ version = "0.1.0"
 [[package]]
 name = "factorial"
 version = "0.1.0"
+
+[[package]]
+name = "factorial"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "factorial-macro"
@@ -2020,6 +2041,14 @@ version = "0.1.0"
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hickerson-series-of-almost-integers"
+version = "0.1.0"
+dependencies = [
+ "decimal 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "factorial 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "higher-order-functions"
@@ -3029,6 +3058,11 @@ name = "optional-parameters"
 version = "0.1.0"
 
 [[package]]
+name = "ord_subset"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,6 +3871,11 @@ dependencies = [
 [[package]]
 name = "rustc-demangle"
 version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -5125,6 +5164,7 @@ version = "0.1.0"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum decimal 2.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e6458723bc760383275fbc02f4c769b2e5f3de782abaf5e7e0b9b7f0368a63ed"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
@@ -5137,6 +5177,7 @@ version = "0.1.0"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum factorial 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "42396d2e190af0797b171935e754dbef0c3df12cacaf52476c502ee3b85d49de"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
@@ -5240,6 +5281,7 @@ version = "0.1.0"
 "checksum openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)" = "ba24190c8f0805d3bd2ce028f439fe5af1d55882bbe6261bed1dbc93b50dd6b1"
+"checksum ord_subset 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7ce14664caf5b27f5656ff727defd68ae1eb75ef3c4d95259361df1eb376bef"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum pango 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45374801e224373c3c0393cd48073c81093494c8735721e81d1dbaa4096b2767"
@@ -5294,6 +5336,7 @@ version = "0.1.0"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "310942406a39981bed7e12b09182a221a29e0990f3e7e0c971f131922ed135d5"
 "checksum rusttype 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa38506b5cbf2fb67f915e2725cb5012f1b9a785b0ab55c4733acda5f6554ef"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -663,6 +663,9 @@ members = [
     # http://rosettacode.org/wiki/Here_document
     "tasks/here-document",
 
+    # https://rosettacode.org/wiki/Hickerson_series_of_almost_integers
+    "tasks/hickerson-series-of-almost-integers",
+
     # http://rosettacode.org/wiki/Higher-order_functions
     "tasks/higher-order-functions",
 

--- a/tasks/hickerson-series-of-almost-integers/Cargo.toml
+++ b/tasks/hickerson-series-of-almost-integers/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hickerson-series-of-almost-integers"
+version = "0.1.0"
+authors = ["Polochon-street <polochonstreet@gmx.fr>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+factorial = "0.2.0"
+decimal = "2.0.4"
+
+[package.metadata.rosettacode]
+url = "https://rosettacode.org/wiki/Hickerson_series_of_almost_integers"

--- a/tasks/hickerson-series-of-almost-integers/src/main.rs
+++ b/tasks/hickerson-series-of-almost-integers/src/main.rs
@@ -1,0 +1,20 @@
+use decimal::d128;
+use factorial::Factorial;
+
+fn hickerson(n: u64) -> d128 {
+    d128::from(n.factorial()) / (d128!(2) * (d128!(2).ln().pow(d128::from(n + 1))))
+}
+
+// Some details on floating-points numbers can be found at https://cheats.rs/#basic-types
+fn main() {
+    for i in 1..18 {
+        let h = hickerson(i);
+        let string = h.to_string();
+        let dec_part = string.split('.').nth(1).unwrap();
+        if dec_part.starts_with('0') || dec_part.starts_with('9') {
+            println!("{} is an almost integer.", h);
+        } else {
+            println!("{} is not an almost integer.", h);
+        }
+    }
+}


### PR DESCRIPTION
This is very much WiP, because my knowledge of floating-points numbers (especially in Rust) is very crude.

If anyone would have some good resources on floating-points numbers it would be much appreciated; I assume the "wrong version" (see below) doesn't work because `f64` doesn't have enough precision? Would there have another way, rather than using `d128`?

https://rosettacode.org/wiki/Hickerson_series_of_almost_integers

Sample output:

```
1.040684490502803898934790801867496 is an almost integer.
Wrong hickerson is 1.0406844905028039
3.002780707156905443499767407219304 is an almost integer.
Wrong hickerson is 3.002780707156906
12.99629050527696646222488454296431 is an almost integer.
Wrong hickerson is 12.996290505276969
74.99873544766160012763455037564470 is an almost integer.
Wrong hickerson is 74.99873544766162
541.0015185164235075692027746182565 is an almost integer.
Wrong hickerson is 541.0015185164236
4683.001247262257437180467152479008 is an almost integer.
Wrong hickerson is 4683.001247262259
47292.99873131462390482283548778628 is an almost integer.
Wrong hickerson is 47292.99873131464
545834.9979074851670672910397944921 is an almost integer.
Wrong hickerson is 545834.9979074855
7087261.001622899120979187515908217 is an almost integer.
Wrong hickerson is 7087261.001622902
102247563.0052710420110883885941994 is an almost integer.
Wrong hickerson is 102247563.00527109
1622632572.997550049852874861078498 is an almost integer.
Wrong hickerson is 1622632572.9975512
28091567594.98157244071518917609951 is an almost integer.
Wrong hickerson is 28091567594.98159
526858348381.0012482861804893808360 is an almost integer.
Wrong hickerson is 526858348381.0016
10641342970443.08453192709507015038 is an almost integer.
Wrong hickerson is 10641342970443.094
230283190977853.0374360391259771066 is an almost integer.
Wrong hickerson is 230283190977853.22
5315654681981354.513076743456805575 is not an almost integer.
Wrong hickerson is 5315654681981359
130370767029135900.4579853491967735 is not an almost integer.
Wrong hickerson is 130370767029136020
```