### PR TITLE
Coverage: make regex less case sensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "sedols"
+version = "0.1.0"
+
+[[package]]
 name = "selection-sort"
 version = "0.1.0"
 dependencies = [

--- a/meta/src/remote.rs
+++ b/meta/src/remote.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 lazy_static! {
     /// Extracts code from the first Rust section from Rosetta Code wiki markup.
     static ref RUST_WIKI_SECTION_RE: Regex =
-        Regex::new(r"==\{\{header\|Rust\}\}==(?s:.*?)<lang rust>((?s:.*?))</lang>").unwrap();
+        Regex::new(r"==\{\{header\|[Rr]ust\}\}==(?s:.*?)<lang [Rr]ust>((?s:.*?))</lang>").unwrap();
 }
 
 define_encode_set! {


### PR DESCRIPTION
The current regex does not find approx. ~40 rust examples at the rosettacode.org site, as in many cases the `header` or the `lang` tag was `rust` and not `Rust`. Alternatively we can convert the complete retrieved text to lowercase and do the regex match on the lowercase text - let me know what would be the preference.