### PR TITLE
modernize currying example

### DIFF
--- a/tasks/currying/src/main.rs
+++ b/tasks/currying/src/main.rs
@@ -1,10 +1,6 @@
-/// `add_n` returns a boxed closure.
-///
-/// TODO: Once "unboxed, abstract return types" are
-/// supported it can be done without the
-/// heap allocation/trait object indirection
-fn add_n(n: i32) -> Box<dyn Fn(i32) -> i32> {
-    Box::new(move |x| n + x)
+/// `add_n` returns a closure.
+fn add_n(n: i32) -> impl Fn(i32) -> i32 {
+    move |x| x + n
 }
 
 fn main() {


### PR DESCRIPTION
We no longer need to box the return value since you can return abstract types.

Original Comment was introduced in b921bd4639e2fe7ce5fcb6b8af15964b18d36901

This article had helpful in-depth explanations of the function signature syntax: https://notes.iveselov.info/programming/rust-closures-combining-move-and-fn
